### PR TITLE
Fix for metrikker for duplikate varselbestillinger

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/dittnav/varselbestiller/metrics/EventMetricsSession.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/varselbestiller/metrics/EventMetricsSession.kt
@@ -28,6 +28,10 @@ class EventMetricsSession(val eventtype: Eventtype) {
         countFailedEksternvarslingBySysUser[systemUser] = countFailedEksternvarslingBySysUser.getOrDefault(systemUser, 0).inc()
     }
 
+    fun countDuplicateEksternvarslingForSystemUser(systemUser: String) {
+        countDuplicateKeyEksternvarslingBySysUser[systemUser] = countDuplicateKeyEksternvarslingBySysUser.getOrDefault(systemUser, 0).inc()
+    }
+
     fun countDuplicateKeyEksternvarslingBySystemUser(result: ListPersistActionResult<Varselbestilling>) {
         result.getConflictingEntities()
                 .groupingBy { varselbestilling -> varselbestilling.systembruker }


### PR DESCRIPTION
Denne metrikken ble ikke rapportert inn tidligere, da den kun så på duplicate keys i databasen. Det slo aldri til, da andre sjekker stoppet varselbestillingen før den kom så langt som til databasen.