### PR TITLE
Gjøre integrasjonstestene m1/colima compliant

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -7,7 +7,7 @@ repositories {
     maven("https://jitpack.io")
 }
 
-val dittNavDependenciesVersion = "2021.09.28-15.20-48db61150cb1"
+val dittNavDependenciesVersion = "2022.01.12-10.45-8becfaec0b57"
 
 dependencies {
     implementation("com.github.navikt:dittnav-dependencies:$dittNavDependenciesVersion")

--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/varselbestiller/common/database/LocalPostgresDatabase.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/varselbestiller/common/database/LocalPostgresDatabase.kt
@@ -29,6 +29,7 @@ class LocalPostgresDatabase : Database {
 
     private fun flyway() {
         Flyway.configure()
+                .connectRetries(3)
                 .dataSource(dataSource)
                 .load()
                 .migrate()


### PR DESCRIPTION
Oppdatert testcontainer, og legg inn flyway-retry for få intergrasjonstester til å fungere på m1-mac med colima.

Det tar litt lenger tid å starte opp testcontainter, usikker på om det er pga m1-macen eller colima, så flyway må prøve et par ganger