### PR TITLE
Midlertidig skru av produsering til kafka

### DIFF
--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/varselbestiller/beskjed/BeskjedIT.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/varselbestiller/beskjed/BeskjedIT.kt
@@ -22,8 +22,10 @@ import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 
+@Disabled
 class BeskjedIT {
 
     private val embeddedEnv = KafkaTestUtil.createDefaultKafkaEmbeddedInstance(listOf(KafkaTestTopics.beskjedTopicName, KafkaTestTopics.doknotifikasjonTopicName))

--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/varselbestiller/done/DoneIT.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/varselbestiller/done/DoneIT.kt
@@ -25,8 +25,10 @@ import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 
+@Disabled
 class DoneIT {
 
     private val embeddedEnv = KafkaTestUtil.createDefaultKafkaEmbeddedInstance(listOf(KafkaTestTopics.doneTopicName, KafkaTestTopics.doknotifikasjonStopTopicName))

--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/varselbestiller/innboks/InnboksIT.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/varselbestiller/innboks/InnboksIT.kt
@@ -22,8 +22,10 @@ import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 
+@Disabled
 class InnboksIT {
 
     private val embeddedEnv = KafkaTestUtil.createDefaultKafkaEmbeddedInstance(listOf(KafkaTestTopics.innboksTopicName, KafkaTestTopics.doknotifikasjonTopicName))

--- a/src/intTest/kotlin/no/nav/personbruker/dittnav/varselbestiller/oppgave/OppgaveIT.kt
+++ b/src/intTest/kotlin/no/nav/personbruker/dittnav/varselbestiller/oppgave/OppgaveIT.kt
@@ -22,8 +22,10 @@ import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 
+@Disabled
 class OppgaveIT {
 
     private val embeddedEnv = KafkaTestUtil.createDefaultKafkaEmbeddedInstance(listOf(KafkaTestTopics.oppgaveTopicName, KafkaTestTopics.doknotifikasjonTopicName))

--- a/src/main/kotlin/no/nav/personbruker/dittnav/varselbestiller/doknotifikasjon/DoknotifikasjonProducer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/varselbestiller/doknotifikasjon/DoknotifikasjonProducer.kt
@@ -18,9 +18,9 @@ class DoknotifikasjonProducer(
     ): ListPersistActionResult<Varselbestilling> {
         val events = successfullyValidatedEvents.map { RecordKeyValueWrapper(it.key, it.value) }
         return try {
-            producer.sendEventsAndLeaveTransactionOpen(events)
+            //producer.sendEventsAndLeaveTransactionOpen(events)
             val result = varselbestillingRepository.persistInOneBatch(varselbestillinger)
-            producer.commitCurrentTransaction()
+            //producer.commitCurrentTransaction()
             result
         } catch (e: Exception) {
             producer.abortCurrentTransaction()

--- a/src/main/kotlin/no/nav/personbruker/dittnav/varselbestiller/doknotifikasjonStopp/DoknotifikasjonStoppProducer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/varselbestiller/doknotifikasjonStopp/DoknotifikasjonStoppProducer.kt
@@ -15,9 +15,9 @@ class DoknotifikasjonStoppProducer(
         val keys = events.map { it.key }
 
         try {
-            producer.sendEventsAndLeaveTransactionOpen(events)
+            //producer.sendEventsAndLeaveTransactionOpen(events)
             varselbestillingRepository.cancelVarselbestilling(keys)
-            producer.commitCurrentTransaction()
+            //producer.commitCurrentTransaction()
         } catch (e: Exception) {
             producer.abortCurrentTransaction()
             throw e


### PR DESCRIPTION
For å fylle opp databasen i gcp uten å sende dupliserte varsler