### PR TITLE
Bruke helsesjekkene i isAlive-proben

### DIFF
--- a/nais/dev-gcp/nais.yaml
+++ b/nais/dev-gcp/nais.yaml
@@ -13,7 +13,7 @@ spec:
   port: 8080
   liveness:
     path: /internal/isAlive
-    initialDelay: 5
+    initialDelay: 30
   readiness:
     path: /internal/isReady
     initialDelay: 5

--- a/nais/prod-gcp/nais.yaml
+++ b/nais/prod-gcp/nais.yaml
@@ -13,7 +13,7 @@ spec:
   port: 8080
   liveness:
     path: /internal/isAlive
-    initialDelay: 5
+    initialDelay: 30
   readiness:
     path: /internal/isReady
     initialDelay: 5

--- a/src/main/kotlin/no/nav/personbruker/dittnav/varselbestiller/common/database/Database.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/varselbestiller/common/database/Database.kt
@@ -50,12 +50,13 @@ interface Database: HealthCheck {
         val serviceName = "Database"
         return withContext(Dispatchers.IO) {
             try {
-                dbQuery { prepareStatement("""SELECT 1""").execute() }
+                dbQuery { prepareStatement("""SELECT 1 from varselbestilling""").execute() }
                 HealthStatus(serviceName, Status.OK, "200 OK")
             } catch (e: Exception) {
                 log.error("Selftest mot databasen feilet", e)
                 HealthStatus(serviceName, Status.ERROR, "Feil mot DB")
-            }}
+            }
+        }
     }
 }
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/varselbestiller/common/database/Database.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/varselbestiller/common/database/Database.kt
@@ -50,7 +50,7 @@ interface Database: HealthCheck {
         val serviceName = "Database"
         return withContext(Dispatchers.IO) {
             try {
-                dbQuery { prepareStatement("""SELECT 1 from varselbestilling""").execute() }
+                dbQuery { prepareStatement("""SELECT * FROM varselbestilling LIMIT 1""").execute() }
                 HealthStatus(serviceName, Status.OK, "200 OK")
             } catch (e: Exception) {
                 log.error("Selftest mot databasen feilet", e)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/varselbestiller/health/healthApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/varselbestiller/health/healthApi.kt
@@ -13,7 +13,11 @@ import io.prometheus.client.exporter.common.TextFormat
 fun Routing.healthApi(healthService: HealthService) {
 
     get("/internal/isAlive") {
-        call.respondText(text = "ALIVE", contentType = ContentType.Text.Plain)
+        if(isAlive(healthService)) {
+            call.respondText(text = "ALIVE", contentType = ContentType.Text.Plain)
+        } else {
+            call.respondText(text = "NOTALIVE", contentType = ContentType.Text.Plain, HttpStatusCode.ServiceUnavailable)
+        }
     }
 
     get("/internal/isReady") {
@@ -35,6 +39,10 @@ fun Routing.healthApi(healthService: HealthService) {
         call.buildSelftestPage(healthService)
     }
 }
+
+private suspend fun isAlive(healthService: HealthService) =
+    healthService.getHealthChecks()
+        .all { healthStatus -> Status.OK == healthStatus.status }
 
 private suspend fun isReady(healthService: HealthService): Boolean {
     val healthChecks = healthService.getHealthChecks()


### PR DESCRIPTION
Bruke helsesjekkene i isAlive-proben, og gjøre database-sjekken mot tabellen for å fange opp migreringsproblemer.

Kan hende det blir noen issues med isAlive ved deploy, hvis migreringer eller noe sånt tar tid. Nå vil den vente i 90 sekunder (30*3) før poden vil restarter. Kan prøve en startup-probe hvis det blir et problem https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-startup-probes